### PR TITLE
add imu monitoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ uuid = { version = "1", features = ["v4"] }
 tokio = { version = "1", features = ["full", "tracing"] }
 tracing-subscriber = "0.3"
 [target.'cfg(target_os = "linux")'.dependencies]
-imu = "0.7.3"
+imu = "0.7.4"
 
 chrono = "0.4"
 once_cell = "1.2"

--- a/src/kbot_imu/hiwonder.rs
+++ b/src/kbot_imu/hiwonder.rs
@@ -116,6 +116,17 @@ impl KBotIMU {
             imu: Arc::new(Mutex::new(imu)),
         })
     }
+
+    pub fn get_effective_frequency(&self) -> Result<f32> {
+        let data = self
+            .imu
+            .lock()
+            .map_err(|e| eyre::eyre!("Failed to lock IMU mutex: {}", e))?
+            .get_data()
+            .map_err(|e| eyre::eyre!("Failed to read IMU data: {}", e))?;
+
+        Ok(data.effective_frequency)
+    }
 }
 
 impl Default for KBotIMU {


### PR DESCRIPTION
### Problem
We want to know when the imu effective frequency drops below 100hz


### Solution
Created async poll loop to log hiwonder's effective frequency to mqtt and give warnings if the frequency is below some desired threshold
 

### Validation
- [x] Manual test steps documented (screenshots, steps, etc.) below:
![image](https://github.com/user-attachments/assets/e61f2f2d-a36b-4a9c-9101-d76710ff043c)
<img width="476" alt="image" src="https://github.com/user-attachments/assets/62ee0c57-42e0-40de-bb47-6bbd71ec5dcd" />

Ran kos-kbot with polling and `scripts/read_imu.py`

### Checklist
- [x] I've completed all the documentation steps above (problem, solution, validation).
- [x] I confirm there's no AI slop in this PR.
- [x] I've updated the documentation to reflect my changes.